### PR TITLE
Compatibility with JGit (TeamCity)

### DIFF
--- a/GitTools/GitHandler.cs
+++ b/GitTools/GitHandler.cs
@@ -167,6 +167,7 @@ namespace GitTools
         {
             var fout = Path.GetTempFileName();
             context.Response.ContentType = string.Format("application/x-git-{0}-advertisement", serviceName);
+            context.Response.Charset = null;
             context.Response.Write(GitString("# service=git-" + serviceName));
             context.Response.Write("0000");
             Git.RunGitCmd(string.Format("{0} --stateless-rpc --advertise-refs \"{1}\" > \"{2}\"", serviceName, gitWorkingDir, fout));


### PR DESCRIPTION
When Write(string) is called on response - it adds "charset=utf-8" to the ContentType, so that raw HTTP header looks like "Content-Type: application/x-git-upload-pack-advertisement; charset=utf-8" and JGit treats that as incorrect. With explicit setting of the Charset everything works fine.
